### PR TITLE
Fix memory leak

### DIFF
--- a/src/PinkTrombone/Tract.cpp
+++ b/src/PinkTrombone/Tract.cpp
@@ -182,6 +182,9 @@ Tract::~Tract()
 
 	if (this->noseMaxAmplitude)
 		free(this->noseMaxAmplitude);
+
+	if (this->transients)
+		free(this->transients);
 }
 
 long Tract::getTractIndexCount()


### PR DESCRIPTION
Detected by valgrind, `transients` is allocated on constructor but never freed.

```
==890428== 480 bytes in 1 blocks are definitely lost in loss record 3,427 of 3,615
==890428==    at 0x6E92A83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0x1F30C08: Tract::Tract(float, float, t_tractProps*) (Tract.cpp:65)
==890428==    by 0x1F28B9E: PinkTrombone::PinkTrombone() (PinkTrombone.cpp:171)
==890428==    by 0x1F2C8F3: rack::CardinalPluginModel<PinkTrombone, PinkTromboneWidget>::createModule() (helpers.hpp:52)
==890428==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428== 
```
